### PR TITLE
Support for Debian-based OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-role-check-mk-agent
 =========
 
-Install and configure the check-mk monitoring agent in CentOS machines
+Install and configure the check-mk monitoring agent in CentOS and Debian machines
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-check_mk_rpm_download_url: 'https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/'
+check_mk_client_download_url: 'https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/'
 
 check_mk_agent_version: '1.6.0p29-1'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 check_mk_client_download_url: 'https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/'
 
-check_mk_agent_version: '1.6.0p29-1'
+check_mk_agent_version: '1.6.0p30-1'
 
 # list of ips which will be allowed to connect to the check_mk agent.
 # these are the two ips in the monitoring hosts

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 check_mk_rpm_download_url: 'https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/'
 
-check_mk_agent_version: '1.4.0p31-2'
+check_mk_agent_version: '1.6.0p29-1'
 
 # list of ips which will be allowed to connect to the check_mk agent.
 # these are the two ips in the monitoring hosts

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,6 +31,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: Debian
 
   galaxy_tags: []
   # List tags for your role here, one per line. A tag is a keyword that describes

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,8 @@
+- name: install xinetd
+  apt:
+    name: xinetd
+    state: present
+- name: install check_mk agent RPM
+  apt:
+    name: "{{ check_mk_rpm_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.deb"
+    state: present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -5,5 +5,5 @@
 
 - name: install check_mk agent DEB
   apt:
-    name: "{{ check_mk_client_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.deb"
+    deb: "{{ check_mk_client_download_url }}/check-mk-agent_{{ check_mk_agent_version }}_all.deb"
     state: present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -4,5 +4,5 @@
     state: present
 - name: install check_mk agent RPM
   apt:
-    name: "{{ check_mk_rpm_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.deb"
+    name: "{{ check_mk_client_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.deb"
     state: present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,8 @@
   apt:
     name: xinetd
     state: present
-- name: install check_mk agent RPM
+
+- name: install check_mk agent DEB
   apt:
     name: "{{ check_mk_client_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.deb"
     state: present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,10 @@
+---
+
+- name: install xinetd
+  yum:
+    name: xinetd
+    state: present
+- name: install check_mk agent RPM
+  yum:
+    name: "{{ check_mk_client_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.rpm"
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include OS Family specific Tasks.
-  ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
+  include_tasks: "{{ ansible_os_family }}.yml"
 
 - name: Configure xinetd to only accept connections from {{ check_mk_monitoring_allowed_ips }}
   lineinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,12 @@
 ---
-
-- name: install xinetd
-  yum:
-    name: xinetd
-    state: present
-
-- name: install check_mk agent RPM
-  yum:
-    name: "{{ check_mk_rpm_download_url }}/check-mk-agent-{{ check_mk_agent_version }}.noarch.rpm"
-    state: present
+- name: Include OS Family specific Tasks.
+  ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
 
 - name: Configure xinetd to only accept connections from {{ check_mk_monitoring_allowed_ips }}
   lineinfile:
     dest: "/etc/xinetd.d/check_mk"
-    regexp: "^(\t)#only_from(.*)$"
-    line: "only_from = {{ check_mk_monitoring_allowed_ips }}"
+    regexp: "^(\t)*(#)*only_from(.*)$"
+    line: "\tonly_from = {{ check_mk_monitoring_allowed_ips }}"
   notify: restart xinetd
 
 - name: Add extra check to /usr/lib/check_mk_agent/plugins/gpfs_mounts so inventory finds gpfs and beegfs mount points


### PR DESCRIPTION
Added support for Debian.
Fixed bug that caused invalid configuration in /etc/xinetd.d/check_mk (see issue #1).